### PR TITLE
Update manifest.js with orientation modification

### DIFF
--- a/js/manifest.js
+++ b/js/manifest.js
@@ -1,13 +1,22 @@
 function modifyManifest(xml, newName, newBundle) {
+	let newOrientation = "landscape"
     const root = xml.documentElement;
+	const app = root.querySelector("application");
+	const activity = app.querySelector("activity");
     let changed = false;
     if (root.tagName !== "manifest") throw new Error("Non-manifest XML document passed");
+	if (newOrientation) {
+		const oldOrientation = activity.getAttribute("android:screenOrientation");
+		if (newOrientation !== oldOrientation) {
+			changed = true;
+			activity.setAttribute("android:screenOrientation", newOrientation);
+		}
+	}
+
     if (newName) {
-	const app = root.querySelector("application");
 	const old = app.getAttribute("android:label");
 	if (newName !== old) {
 	    app.setAttribute("android:label", newName) 
-	    const activity = app.querySelector("activity");
 	    activity.setAttribute("android:label", newName);
 	    changed = true;
 	}

--- a/js/manifest.js
+++ b/js/manifest.js
@@ -1,5 +1,5 @@
 function modifyManifest(xml, newName, newBundle) {
-	let newOrientation = "landscape"
+	let newOrientation = "6"
     const root = xml.documentElement;
 	const app = root.querySelector("application");
 	const activity = app.querySelector("activity");


### PR DESCRIPTION
closes #14, this just does the bare minimum, i set the variable to landscape because i'm too lazy right now to make an entire UI, plus i'm not sure if it would be up to your standards.
If you do end up merging this, you can make `newOrientation` an argument of `modifyManifest`, then simply put the orientation selection in on the step where you select the bundle ID.